### PR TITLE
Create

### DIFF
--- a/nuget.config
+++ b/nuget.config
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="NuGet Public" value="https://api.nuget.org/v3/index.json" />
+  </packageSources>   
+</configuration>

--- a/nuget.config
+++ b/nuget.config
@@ -1,7 +1,22 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
-  <packageSources>
-    <clear />
-    <add key="NuGet Public" value="https://api.nuget.org/v3/index.json" />
-  </packageSources>   
+   <packageSources>
+     <clear />
+     <add key="NuGet Public" value="https://api.nuget.org/v3/index.json" />
+   </packageSources>
+   <!--
+       Used to specify trusted signers to allow during signature verification.
+       See: nuget.exe help trusted-signers
+   -->
+   <trustedSigners>
+       <author name="microsoft">
+           <certificate fingerprint="3F9001EA83C560D712C24CF213C3D312CB3BFF51EE89435D3430BD06B5D0EECE" hashAlgorithm="SHA256" allowUntrustedRoot="false" />
+           <certificate fingerprint="AA12DA22A49BCE7D5C1AE64CC1F3D892F150DA76140F210ABD2CBFFCA2C18A27" hashAlgorithm="SHA256" allowUntrustedRoot="false" />
+       </author>
+       <repository name="nuget.org" serviceIndex="https://api.nuget.org/v3/index.json">
+           <certificate fingerprint="0E5F38F57DC1BCC806D8494F4F90FBCEDD988B46760709CBEEC6F4219AA6157D" hashAlgorithm="SHA256" allowUntrustedRoot="false" />
+           <certificate fingerprint="5A2901D6ADA3D18260B9C6DFE2133C95D74B9EEF6AE0E5DC334C8454D1477DF4" hashAlgorithm="SHA256" allowUntrustedRoot="false" />
+           <owners>microsoft;aspnet;nuget</owners>
+       </repository>
+   </trustedSigners>
 </configuration>


### PR DESCRIPTION
Added config file to test .Net supplychain. Also noticed the error below when attempting to scan. 
`k logs scanxxx` shows the message below:

---
scan-weatherforecast-steeltoe-kl8s9-2bj62 scan-plugin MSBuild version 17.3.2+561848881 for .NET
scan-weatherforecast-steeltoe-kl8s9-2bj62 scan-plugin   Determining projects to restore...
scan-weatherforecast-steeltoe-kl8s9-2bj62 scan-plugin /workspace/source/repo/steeltoe.csproj : error NU1301: Unable to load the service index for source https://api.nuget.org/v3/index.json. [/workspace/source/repo/steeltoe.sln]
scan-weatherforecast-steeltoe-kl8s9-2bj62 scan-plugin /workspace/source/repo/steeltoe.csproj : error NU1301: Unable to load the service index for source https://api.nuget.org/v3/index.json. [/workspace/source/repo/steeltoe.sln]
scan-weatherforecast-steeltoe-kl8s9-2bj62 scan-plugin /workspace/source/repo/steeltoe.csproj : error NU1301: Unable to load the service index for source https://api.nuget.org/v3/index.json. [/workspace/source/repo/steeltoe.sln]
scan-weatherforecast-steeltoe-kl8s9-2bj62 scan-plugin   Failed to restore /workspace/source/repo/steeltoe.csproj (in 18.49 sec).
scan-weatherforecast-steeltoe-kl8s9-2bj62 scan-plugin
scan-weatherforecast-steeltoe-kl8s9-2bj62 scan-plugin Build FAILED.

---

Seems that there's some kind of cert issues that `dotnet restore ....` is expecting.  This is the command that ran to build the app on scan-plugin container.  Apparently there needs to be some kind of caCert file so it can reach out  https://api.nuget.org/v3/index.json.

Refs: 
https://learn.microsoft.com/en-us/nuget/reference/nuget-config-file#config-section
https://developercommunity.visualstudio.com/t/dotnet-restore-skip-ssl-verfication/1228989
https://stackoverflow.com/questions/54177235/how-to-use-non-default-ca-certs-for-dotnet-core-and-nuget
https://github.com/dotnet/core/issues/5134
https://zimmergren.net/nuget-error-unable-load-service-index-for-source-unauthorized/

